### PR TITLE
Make control panel scrollable in landscape

### DIFF
--- a/index_gpu.html
+++ b/index_gpu.html
@@ -63,7 +63,9 @@
       padding:16px;
       position: relative;
       max-width: 520px;
-      overflow: hidden;
+      max-height: calc(100vh - 24px);
+      overflow-y: auto;
+      overflow-x: hidden;
     }
 
     /* Portrait: controls under canvas, scroll inside panel */


### PR DESCRIPTION
## Summary
- Ensure the controls panel can scroll when taller than the screen even in landscape mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b43c233c8c83228bc0b1831ffe1663